### PR TITLE
Update MD_AButton.h

### DIFF
--- a/src/MD_AButton.h
+++ b/src/MD_AButton.h
@@ -30,7 +30,7 @@ const uint8_t KEY_NONE = '\0';
 class MD_AButton 
 {
 public:
-  MD_AButton::MD_AButton(uint8_t keyPin) :
+  MD_AButton(uint8_t keyPin) :
       _keyPin(keyPin), _lastKey(KEY_NONE),
       _lastReadTime(0), _lastKeyTime(0),
       _timeDetect(50), _timeRepeat(300)


### PR DESCRIPTION
Syntax error on class contructor... somehow the compiler do not give error if you compile for Arduino's boards, instead it does for ESP8266.

I really liked your work and I'm using some of your libraries for a project I'm developing for an ESP8266. So, I migth have some tips for the MD_MENU library, but they are still under test.